### PR TITLE
Do not require "digest" dynamo column

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "projects": ["src","test"]
+    "projects": ["src","test"],
+    "sdk": {
+    "version": "1.0.0-preview2-003131"
+  }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "projects": ["src","test"],
     "sdk": {
-    "version": "1.0.0-preview2-003131"
+    	"version": "1.0.0-preview2-003131"
   }
 }

--- a/src/Narochno.Credstash/Internal/CredstashItem.cs
+++ b/src/Narochno.Credstash/Internal/CredstashItem.cs
@@ -14,12 +14,12 @@ namespace Narochno.Credstash
 
         public static CredstashItem From(Dictionary<string, AttributeValue> item)
         {
-            return new CredstashItem()
+            return new CredstashItem
             {
                 Name = item["name"].S,
                 Version = item["version"].S,
                 Contents = item["contents"].S,
-                Digest = item["digest"].S,
+                Digest = item.ContainsKey("digest") ? item["digest"].S : null,
                 Hmac = item["hmac"].S,
                 Key = item["key"].S,
             };


### PR DESCRIPTION
The digest column is not currently utilized for anything in retrieval. 
I have an implementation of credstash and I need a .net core client for but with the use of a required "digest" column in the schema.

I also added the explicit SDK version to avoid any runtime conflicts with newer .net core preview versions.