### PR TITLE
Update Credstash Item for Dict Key Check before Null Check

### DIFF
--- a/src/Narochno.Credstash/Internal/CredstashItem.cs
+++ b/src/Narochno.Credstash/Internal/CredstashItem.cs
@@ -21,7 +21,7 @@ namespace Narochno.Credstash.Internal
                 Name = item["name"].S,
                 Version = item["version"].S,
                 Contents = item["contents"].S,
-                Digest = item["digest"]?.S ?? DEFAULT_DIGEST,
+                Digest = (item.ContainsKey("digest") ? item["digest"]?.S : null) ?? DEFAULT_DIGEST,
                 Hmac = item["hmac"].S,
                 Key = item["key"].S,
             };


### PR DESCRIPTION
I updated to perform a check if the key exists in the dictionary before the default null check. Otherwise before the inline null check is performed, it will fail if the "digest" key isn't even present in the dictionary. 