### PR TITLE
Add missing ConfigureAwait(false) to avoid locking in case of paralle…

### DIFF
--- a/src/Narochno.Credstash.Configuration/CredstashConfigurationProvider.cs
+++ b/src/Narochno.Credstash.Configuration/CredstashConfigurationProvider.cs
@@ -30,7 +30,7 @@ namespace Narochno.Credstash.Configuration
         {
             var data = new Dictionary<string, string>();
 
-            var entries = (await _credstash.ListAsync()).Select(x => x.Name).Distinct().ToList();
+            var entries = (await _credstash.ListAsync().ConfigureAwait(false)).Select(x => x.Name).Distinct().ToList();
 
             if (entries.Count() > 10 && _degreeOfParallelism > 1)
             {

--- a/src/Narochno.Credstash.Configuration/Narochno.Credstash.Configuration.csproj
+++ b/src/Narochno.Credstash.Configuration/Narochno.Credstash.Configuration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <Authors>adamhathcock</Authors>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Narochno.Credstash.Configuration</AssemblyName>

--- a/src/Narochno.Credstash/Narochno.Credstash.csproj
+++ b/src/Narochno.Credstash/Narochno.Credstash.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.3.0</VersionPrefix>
+    <VersionPrefix>2.4.0</VersionPrefix>
     <Authors>adamhathcock</Authors>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Narochno.Credstash</AssemblyName>


### PR DESCRIPTION
Hello guys,

I have added a ConfigureAwait(false) to the LoadAsync method because in case of parallel test execution the LoadAsync().Result call caused dead lock. 

BTW it is strange why the Load method of the base class is not async.

Thanks,
Tamas 