### PR TITLE
Update versions, and fix concurrent access problem

### DIFF
--- a/misc/CredstashTester/CredstashTester.csproj
+++ b/misc/CredstashTester/CredstashTester.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>CredstashTester</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/Narochno.Credstash.Configuration/Narochno.Credstash.Configuration.csproj
+++ b/src/Narochno.Credstash.Configuration/Narochno.Credstash.Configuration.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <Authors>adamhathcock</Authors>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Narochno.Credstash.Configuration</AssemblyName>
@@ -15,6 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Narochno.Credstash/Narochno.Credstash.csproj
+++ b/src/Narochno.Credstash/Narochno.Credstash.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>2.5.0</VersionPrefix>
+    <VersionPrefix>2.6.0</VersionPrefix>
     <Authors>adamhathcock</Authors>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <AssemblyName>Narochno.Credstash</AssemblyName>
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.4.17" />
-    <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.3.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.12.2" />
+    <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.6.4" />
     <PackageReference Include="Narochno.Primitives" Version="2.6.6" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.1.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We get this exception, and this is why I changed Dictionary to ConcurrentDictionary:

Result StackTrace:	
at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Narochno.Credstash.Configuration.CredstashConfigurationProvider.Load()
   at Microsoft.Extensions.Configuration.ConfigurationRoot..ctor(IList`1 providers)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at ...

----- Inner Stack Trace -----
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at Narochno.Credstash.Configuration.CredstashConfigurationProvider.SetConfigValueAsync(Dictionary`2 data, String entry)
   at Narochno.Credstash.Configuration.CredstashConfigurationProvider.<>c__DisplayClass6_0.<<LoadAsync>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Narochno.Credstash.Configuration.ParallelExtensions.<>c__DisplayClass0_1`1.<<ForEachAsync>b__1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Narochno.Credstash.Configuration.CredstashConfigurationProvider.LoadAsync()
Result Message:	
System.AggregateException : One or more errors occurred. (Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.)
---- System.InvalidOperationException : Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.